### PR TITLE
Added force to TLS 1.2 for session.

### DIFF
--- a/SpanningO365/Private/Invoke-SpanningRequest.ps1
+++ b/SpanningO365/Private/Invoke-SpanningRequest.ps1
@@ -83,6 +83,12 @@
        $AuthInfo = Get-AuthInfo
     }
 
+    # Force TLS 1.2
+    if ([Net.ServicePointManager]::SecurityProtocol -ne [Net.SecurityProtocolType]::SystemDefault){
+      Write-Verbose "Applying TLS 1.2"
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    }
+
     $headers = $AuthInfo.Headers
     $region = $AuthInfo.Region
     $method = "GET"

--- a/SpanningO365/SpanningO365.psd1
+++ b/SpanningO365/SpanningO365.psd1
@@ -12,7 +12,7 @@
     RootModule = '.\SpanningO365.psm1'
     
     # Version number of this module.
-    ModuleVersion = '4.0.0.0'
+    ModuleVersion = '4.0.0.1'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
I see that some users are having issues with their environments using less secure TLS 1 or 1.1. We have turned off support for TLS below 1.2 for API access. This minor update ensures that the session is using TLS 1.2 (or SystemDefault). If it turns out that this is not sufficient, I'll change it again and just force TLS 1.2. 
Closes #34 
