### PR TITLE
API Update

### DIFF
--- a/SpanningO365/Private/Invoke-SpanningRequest.ps1
+++ b/SpanningO365/Private/Invoke-SpanningRequest.ps1
@@ -110,6 +110,9 @@
     $method = "GET"
     $apiRootUrl = "https://o365-api-$region.spanningbackup.com/external"
 
+    #ProgressPreference prevents wasted time showing progress. This improves the processing time.
+    $ProgressPreference = "SilentlyContinue"
+
     Write-Verbose "Invoke-SpanningRequest Request Type $($RequestType)"
 
     switch ( $RequestType )

--- a/SpanningO365/Private/Invoke-SpanningRequest.ps1
+++ b/SpanningO365/Private/Invoke-SpanningRequest.ps1
@@ -121,20 +121,59 @@
           Write-Verbose "Invoke-SpanningRequest UPN null"
           Write-Verbose "Invoke-SpanningRequest size parameter is: $Size"
 
-          $request = "$apiRootUrl/users?size=$Size"
-           #TODO : Clean this up
-          $values2 = @()
-          $values = @()
-          $response = Invoke-WebRequest -uri $request -Headers $headers -Method GET -UseBasicParsing | ConvertFrom-Json
-          $values2 += $response.users
-          do {
-              $response = Invoke-WebRequest -uri $response.nextLink -Headers $headers -Method GET -UseBasicParsing | ConvertFrom-JSON
-              $values += $response.users
-          } until ($response.nextlink.Length -eq 0)
+          $Uri = "$apiRootUrl/users?size=$Size"
 
-          #$values.count
-          $values3 = $values2 + $values
-          $results = $values3
+          $retryCount = 0
+          $maxRetries = 3
+          $pauseDuration = 2
+          $allRecords = @()
+
+          while ($null -ne $Uri){
+              Write-Verbose "Request URI: $Uri"
+              try {
+
+                  $query = Invoke-WebRequest -uri $Uri -Headers $headers -Method GET -UseBasicParsing | ConvertFrom-Json
+                  $allRecords += $query.users
+
+                  if($query.nextLink){
+                      # set the url to get the next page of records
+                      $Uri = $query.nextLink
+                  } else {
+                      $Uri = $null
+                  }
+
+              } catch {
+                #TODO : Mock this to test responses
+                  Write-Verbose "StatusCode: " $_.Exception.Response.StatusCode.value__
+                  Write-Verbose "StatusDescription:" $_.Exception.Response.StatusDescription
+
+                  if($_.ErrorDetails.Message){
+                      Write-Verbose "Inner Error: $_.ErrorDetails.Message"
+                  }
+
+                  # Check for a 429 in case we need to slow down
+                  if($_.Exception.Response.StatusCode.value__ -eq 429 ){
+                      #If it's a 429 you can get the retry after
+                      #$retryAfter = $_.Exception.Response.Headers["Retry-After"]
+                      # just ignore, leave the url the same to retry but pause first
+                      if($retryCount -ge $maxRetries){
+                          # not going to retry again
+                          $Uri = $null
+                          Write-Verbose 'Not going to retry...'
+                      } else {
+                          $retryCount += 1
+                          Write-Verbose "Retry attempt $retryCount after a $pauseDuration second pause..."
+                          Start-Sleep -Seconds $pauseDuration
+                      }
+
+                  } else {
+                      # not going to retry -- set the url to null to fall back out of the while loop
+                      $Uri = $null
+                  }
+              }
+          }
+
+          $results = $allRecords #| ConvertTo-Json
 
           Write-Verbose "Invoke-SpanningRequest User Loop"
 

--- a/SpanningO365/Public/Enable/Enable-SpanningUser.ps1
+++ b/SpanningO365/Public/Enable/Enable-SpanningUser.ps1
@@ -49,7 +49,7 @@
     )
     Write-Verbose "Enable-SpanningUser"
 
-    Write-Warning "Enable-SpanningUser id deprecated, use Enable-SpanningUserList instead"
+    Write-Warning "Enable-SpanningUser is deprecated, use Enable-SpanningUserList instead"
 
     if (!$AuthInfo) {
        Write-Verbose "No AuthInfo provided, checking Session State"

--- a/SpanningO365/Public/Get/Get-SpanningUser.ps1
+++ b/SpanningO365/Public/Get/Get-SpanningUser.ps1
@@ -13,6 +13,9 @@
         This parameter filters to specific user types from the set All, Admins, NonAdmins, Assigned, Unassigned, Deleted (from Active Directory), NotDeleted.
     .PARAMETER Size
         This parameter takes a page size parameter for the request. It defaults to 1000.
+    .PARAMETER Status
+        This parameter takes an optional parameter to include the User Backup Status in the result.
+        Note, this can significantly increase both the result size and the time required for PowerShell to process the results.
     .EXAMPLE
         Get-SpanningUser -UserPrincipalName ruby@doghousetoys.com
         Without any parameters you will be prompted for ApiToken, Region, and AdminEmail if Get-SpanningAuthentication has not been previously called.
@@ -66,7 +69,15 @@
             ParameterSetName = "Get Multiple Users")]
         [Int]
         #Request Size parameter for User requests, default 1000
-        $Size = 1000
+        $Size = 1000,
+        [Parameter(
+            Position=4,
+            Mandatory=$false,
+            ValueFromPipeline=$true,
+            ValueFromPipelineByPropertyName=$true)]
+        [bool]
+        #Include backup status for users $false by default
+        $Status = $false
     )
     Write-Verbose "Get-SpanningUser"
 
@@ -79,7 +90,7 @@
     # #TODO : Clean this up
     if ($UserType){
         Write-Verbose "UserType: $($UserType) - Invoke-SpanningRequest"
-        $temp_users = Invoke-SpanningRequest -AuthInfo $AuthInfo -RequestType User -Size $Size
+        $temp_users = Invoke-SpanningRequest -AuthInfo $AuthInfo -RequestType User -Size $Size -Status $Status
     }
 
     switch ( $UserType )
@@ -130,7 +141,7 @@
         {
             Write-Verbose 'UserType = null'
             # Return the User
-            $results = Invoke-SpanningRequest -AuthInfo $AuthInfo -RequestType User -UserPrincipalName $UserPrincipalName -Size $Size
+            $results = Invoke-SpanningRequest -AuthInfo $AuthInfo -RequestType User -UserPrincipalName $UserPrincipalName -Size $Size -Status $Status
             Write-Output $results
         }
     }

--- a/SpanningO365/SpanningO365.Integration.Tests.ps1
+++ b/SpanningO365/SpanningO365.Integration.Tests.ps1
@@ -111,7 +111,7 @@ Describe "Get-SpanningTenantInfo Integration Test" -Tag "Integration" {
 	Context "Get-SpanningUser" {
 		
 		It "Get-SpanningUser - by UPN" {
-			$(Get-SpanningUser -UserPrincipalName $AdminEmail).userInfo.email | Should -Be $AdminEmail
+			$(Get-SpanningUser -UserPrincipalName $AdminEmail).userPrincipalName | Should -Be $AdminEmail
 		}
 		
 		It "Get-SpanningUser - by Type Admins" {

--- a/SpanningO365/SpanningO365.Integration.Tests.ps1
+++ b/SpanningO365/SpanningO365.Integration.Tests.ps1
@@ -12,11 +12,6 @@ A Pester integration test file for the SpanningO365 module. This file uses
 the local file system and runs the functions in the module together to verify
 that they run correctly.
 
-#Pester 3 & 4 Syntax
-$params = @{ApiToken = 'whosagoo-ddog-ruby-isagoodgirlright!'; Region = 'US'; AdminEmail = 'ruby@sharepointdog.com'}
-$test = @{Path =  '.\SpanningO365.Integration.Tests.ps1'; Parameters = $params}
-Invoke-Pester -Script $test
-
 #Pester 5.1 Syntax
 $params = @{ApiToken = 'whosagoo-ddog-ruby-isagoodgirlright!'; Region = 'US'; AdminEmail = 'ruby@sharepointdog.com'}
 $container = New-PesterContainer -Path './SpanningO365.Integration.Tests.ps1' -Data $params

--- a/SpanningO365/SpanningO365.Integration.Tests.ps1
+++ b/SpanningO365/SpanningO365.Integration.Tests.ps1
@@ -77,7 +77,7 @@ Describe "Get-SpanningTenantInfo Integration Test" -Tag "Integration" {
 		}
 
 		It "Get-SpanningTenantBackupSummary - 4 Day Range" {
-			(Get-SpanningTenantBackupSummary -StartDate (Get-Date).AddDays(-6) -EndDate (Get-Date).AddDays(-2) | Where-Object {$_.type -eq "MAIL"}).Count | Should -Be 4
+			(Get-SpanningTenantBackupSummary -StartDate (Get-Date).AddDays(-6) -EndDate (Get-Date).AddDays(-2) | Where-Object {$_.type -eq "MAIL"}).Count | Should -BeGreaterOrEqual 4
 		}
 
 		It "Get-SpanningTenantBackupSummary - Includes Workload MAIL" {

--- a/SpanningO365/SpanningO365.Pester5.Tests.ps1
+++ b/SpanningO365/SpanningO365.Pester5.Tests.ps1
@@ -11,7 +11,7 @@
 
 #Pester 5.1 Syntax
 $params = @{Module = "SpanningO365"}
-$container = New-PesterContainer -Path ".\SpanningO365\Private\" -Data $params
+$container = New-PesterContainer -Path ".\SpanningO365.Pester5.Tests.ps1" -Data $params
 Invoke-Pester -Container $container -Output Detailed -TagFilter "Structure", "Function"
 
 

--- a/SpanningO365/SpanningO365.psd1
+++ b/SpanningO365/SpanningO365.psd1
@@ -12,7 +12,7 @@
     RootModule = '.\SpanningO365.psm1'
     
     # Version number of this module.
-    ModuleVersion = '4.1.0.0'
+    ModuleVersion = '4.2.0.0'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/sample-license-users.md
+++ b/sample-license-users.md
@@ -77,7 +77,7 @@ if ($availableLicenses -lt $usersToLicense.Count){
 if (!$aborted){
     if ($availableLicenses -gt 0){
         # Note the -WhatIf parameter, this is for testing the script. Remove it for production
-        Enable-SpanningUserList -UserPrincipalNames $usersToLicense -WhatIf
+        Enable-SpanningUserList -UserPrincipalNames $usersToLicense.userPrincipalName -WhatIf
     } else {
         Write-Warning "You are out of licenses"
         break


### PR DESCRIPTION
This update uses the new `-Status` flag set to `false` to reduce the payload return size and improve performance of `Get-SpanningUser...` cmdlets in PowerShell. 

If you want the backup status for the user set the `-Status` flag to `$true`.