### PR TITLE
Added Progress bar to Compare the two lists

### DIFF
--- a/sample-license-users.md
+++ b/sample-license-users.md
@@ -52,12 +52,18 @@ $unlicensedUsers = Get-SpanningUser -UserType Unassigned
 ```powershell
 $usersToLicense = @()
 
+$UserCount = $licensedO365Users.count
+$i = 0
 foreach ($user in $licensedO365Users){
+    $i = $i + 1
+    $pct = $i/$UserCount * 100
+    Write-Progress -Activity "Checking Users" -Status "Processing Call QueueUSer $i of $UserCount - $($user.UserPrincipalName)" -PercentComplete $pct
     $userNeedsSpanning = $unlicensedUsers | where {$_.userPrincipalName -eq $user.UserPrincipalName}
     if ($userNeedsSpanning){
         $usersToLicense += $userNeedsSpanning
     }
 }
+Write-Progress -Activity "Checking Users" -Completed
 ```
 
 ## Test if you have enough licenses and offer an about


### PR DESCRIPTION
When dealing with large amount of users, it's good to see the progress of the check to ensure it's still running, adding Write-Progress to Compare the two lists really helped to know how far it got.